### PR TITLE
Add texlive & dvidvi for building sphinx/pdf documentations.

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get -qqy update && apt-get -y install \
     libxml2-dev libxslt1-dev lsb-release pdftk pkg-config redis-server rsync \
     ttf-dejavu wget zlib1g-dev \
     python python-dev python3-dev \
-    python-pip python3-pip
+    python-pip python3-pip \
+    texlive-latex-recommended texlive-latex-extra \
+    texlive-fonts-recommended texlive-lang-french dvidvi
 
 # Locales
 RUN echo "LANG=en_US.UTF-8" > /etc/default/locale && \


### PR DESCRIPTION
Sphinx can build PDF documentations, but requires heavy texlive and dvidvi for that.
Makes sense to put it in the docker base image because the packages are very heavy (750MiB)
